### PR TITLE
Devops/switch ports (completes PRA-59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,28 @@ This will be the front-end for your team's practicum project.
 It is suggested that you run these instructions **after** you setup the back-end server first.
 You can go through these steps during your first group meeting in case you need assistance from your mentors.
 
-You will have two folders inside one team folder (one for front-end and one for back-end). Name the parent folder something appropriate (in the below example we title it "Practicum Project").  Then clone directly (do not fork and clone) the front and back repos while inside the parent ("Practicum Project") project folder.
+You will have two folders inside one team folder (one for front-end and one for back-end). Name the parent folder something appropriate (in the below example we title it "Practicum Project"). Then clone directly (do not fork and clone) the front and back repos while inside the parent ("Practicum Project") project folder.
 
 ![folders](images/folder_structure.png)
 
->The front-end app (React) will be running on port 3000. The back-end server will be running on port 8000. You will need to run both the front-end app and the back-end server at the same time to test your app.
+> The front-end app (React) will be running on port 3000. The back-end server will be running on port 8000. You will need to run both the front-end app and the back-end server at the same time to test your app.
 
 ### Setting up local development environment
 
 1. Clone this repository to the folder that was already created for both the front-end and back-end repos
 2. Run `npm install` to install dependencies
-3. Pull the latest version of the `main` branch (when needed)
-4. Run `npm start` to start the development server
-5. Open http://localhost:3000 with your browser to see the data received the back-end server.
-6. Now you have your front-end and back-end running locally!
+3. Add a file to the top level of your folder named `.env.local`
+4. In this file, add `PORT=3005`
+5. Pull the latest version of the `main` branch (when needed)
+6. Run `npm start` to start the development server
+7. Open http://localhost:3000 with your browser to see the data received the back-end server.
+8. Now you have your front-end and back-end running locally!
 
 #### Running the front-end server in Visual Studio Code
-Note: In the below example, the group's front-end repository was named `bb-practicum-team1-front` and the back-end repository was named `bb-practicum-team-1-back`.  Your repository will have a different name, but the rest should look the same.
+
+Note: In the below example, the group's front-end repository was named `bb-practicum-team1-front` and the back-end repository was named `bb-practicum-team-1-back`. Your repository will have a different name, but the rest should look the same.
 ![vsc running](images/front-end-running-vsc.png)
 
 #### Running the front-end server in the browser
+
 ![browser running](images/front-end-running-browser.png)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,22 @@
 import React, { useState, useEffect } from "react";
-import { Heading, Link } from "@chakra-ui/react";
+import { Heading, Link, Text } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 
 import { getAllData } from "./util/index";
 
-const URL = "http://localhost:8000/api/v1/";
+const URL = "http://localhost:3000/api/v1/";
 
 function App() {
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState<string>("");
+  const [textColor, setTextColor] = useState<string>("black");
 
   useEffect(() => {
-    (async () => {
-      const myData = await getAllData(URL);
-      setMessage(myData.data);
-    })();
+    getAllData(URL)
+      .then((response) => setMessage(response.data))
+      .catch((error) => {
+        setTextColor("red");
+        setMessage(error.message);
+      });
 
     return () => {
       console.log("unmounting");
@@ -22,10 +25,14 @@ function App() {
 
   return (
     <>
-      <Heading>{message}</Heading>
+      <Heading>Welcome to Our App</Heading>
       <Link as={RouterLink} to="/home">
         HOME
       </Link>
+
+      <Text
+        color={textColor}
+      >{`Response from request to ${URL}: ${message}`}</Text>
     </>
   );
 }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,25 +1,26 @@
 import axios from "axios";
- 
+
 // note: not used, but could be used with GET with params
- const getData = async (url, params) => {
-    try {
-      let res = await axios.get(url, params);
-      let data = await res.data;
-      return data;
-    } catch (error) {
-      console.log(error, `error - getData in ${url} route`);
-    }
-  };
+const getData = async (url, params) => {
+  try {
+    let res = await axios.get(url, params);
+    let data = await res.data;
+    return data;
+  } catch (error) {
+    console.log(error, `error - getData in ${url} route`);
+    return error;
+  }
+};
 
-  const getAllData = async (url) => {
-    try {
-      let res = await axios.get(url);
-      let data = await res.data;
-      return data;
-    } catch (error) {
-      console.log(error, `error - getAllData in ${url} route`);
-    }
-  };
+const getAllData = async (url) => {
+  try {
+    let res = await axios.get(url);
+    let data = await res.data;
+    return data;
+  } catch (error) {
+    console.log(error, `error - getAllData in ${url} route`);
+    throw error;
+  }
+};
 
-
-  export {getData, getAllData};
+export { getData, getAllData };


### PR DESCRIPTION
## One Line Description
Switch API port from 8000 to 3000. Switch React app port from 3000 to 3005. Add better API error handling

## Requirements
* Front end app should run on port 3005
* When the API is not working, no TypeScript errors should show up
* Response from API should be black if successful and red if not.

## Notes
We'll want more sophisticated error handling later, but this should make things a little easier for now.

## Test Steps
* Add `.env.local` file to top level of repository locally
* Add variable `PORT = 3005` to the env file
* Run back end
* Run front end
* Verify that app loads successfully and renders message about response from API route in black
* Shut down back end
* Refresh front end app in browser - verify that the message about the API response is now in red and says "network error"

## Checklist

- The Linear ID is in the PR title
- My code follows best practices
- Documentation is included where needed
