### PR TITLE
added "other" handle (PRA-182)

### DIFF
--- a/src/components/RecipeAI/IngredientList.tsx
+++ b/src/components/RecipeAI/IngredientList.tsx
@@ -13,7 +13,8 @@ const IngredientList = ({ ingredient }: IngredientProps) => {
          ingredient.quantity === "to taste" ||
          ingredient.quantity === "for serving" ||
          ingredient.quantity === "for garnish" ||
-         ingredient.unit === "unit"
+         ingredient.unit === "unit" ||
+         ingredient.unit === "other"
            ? ""
            : ingredient.unit
        }


### PR DESCRIPTION
## One Line Description
we had unit === "other" that wasn't handle during rendering AI recipe
## Requirements

_What this code should do_
do not show "other" when recipe render after AI search
## Notes

_Any additional info_

## Test Steps

_Instructions on how to test the changes_

## UI/UX Outcome

_Attach a screenshot here_
before: 
<img width="332" alt="Pasted Graphic" src="https://github.com/Code-the-Dream-School/dd-prac-team1-front/assets/106414157/24c4bbc4-ede5-438a-b49a-9214cedd4410">
after: 
<img width="254" alt="image" src="https://github.com/Code-the-Dream-School/dd-prac-team1-front/assets/106414157/a2d9e5b1-54ea-451e-94ad-7e14d19d010c">


## Checklist

- The Linear ID is in the PR title
- My code follows best practices
- Documentation is included where needed
