### PR TITLE
handle -4 and -5 in recipe amount (PRA-184)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Stavok"]
+  "cSpell.words": ["instuctions", "Stavok"]
 }

--- a/src/components/EditRecipe/IngredientAmountHandle.tsx
+++ b/src/components/EditRecipe/IngredientAmountHandle.tsx
@@ -17,6 +17,8 @@ const IngredientAmountHandle = ({
     if (ingredient.ingredientAmount === -1) setMode(-1);
     if (ingredient.ingredientAmount === -2) setMode(-2);
     if (ingredient.ingredientAmount === -3) setMode(-3);
+    if (ingredient.ingredientAmount === -4) setMode(-4);
+    if (ingredient.ingredientAmount === -5) setMode(-5);
   }, [ingredient.ingredientAmount]);
 
   return (
@@ -37,6 +39,8 @@ const IngredientAmountHandle = ({
           <option value="-1">to taste</option>
           <option value="-2">for serving</option>
           <option value="-3">for garnish</option>
+          <option value="-4">to serve</option>
+          <option value="-5">to garnish</option>
         </Select>
       </FormControl>
       {mode === 0 && (

--- a/src/components/RecipeManual/DropImage.tsx
+++ b/src/components/RecipeManual/DropImage.tsx
@@ -1,227 +1,217 @@
 import { ChangeEventHandler, forwardRef, useRef } from "react";
 import {
-    AspectRatio,
-    Box,
-    Button,
-    Flex,
-    Input,
-    Stack,
-    Image as ChakraImage,
-    FormControl
+  AspectRatio,
+  Box,
+  Button,
+  Flex,
+  Input,
+  Stack,
+  Image as ChakraImage,
+  FormControl
 } from "@chakra-ui/react";
 import { motion, useAnimation } from "framer-motion";
-import { AnimationVariants } from "../../utils/types"; 
+import { AnimationVariants } from "../../utils/types";
 
 const first = {
-    rest: {
-        rotate: "-15deg",
-        scale: 0.95,
-        x: "-50%",
-        filter: "grayscale(80%)",
-        transition: {
-        duration: 0.5,
-        type: "tween",
-        ease: "easeIn"
-        }
-    },
-    hover: {
-        x: "-70%",
-        scale: 1.1,
-        rotate: "-20deg",
-        filter: "grayscale(0%)",
-        transition: {
-        duration: 0.4,
-        type: "tween",
-        ease: "easeOut"
-        }
+  rest: {
+    rotate: "-15deg",
+    scale: 0.95,
+    x: "-50%",
+    filter: "grayscale(80%)",
+    transition: {
+      duration: 0.5,
+      type: "tween",
+      ease: "easeIn"
     }
-    };
+  },
+  hover: {
+    x: "-70%",
+    scale: 1.1,
+    rotate: "-20deg",
+    filter: "grayscale(0%)",
+    transition: {
+      duration: 0.4,
+      type: "tween",
+      ease: "easeOut"
+    }
+  }
+};
 
-    const second = {
-    rest: {
-        rotate: "15deg",
-        scale: 0.95,
-        x: "50%",
-        filter: "grayscale(80%)",
-        transition: {
-        duration: 0.5,
-        type: "tween",
-        ease: "easeIn"
-        }
-    },
-    hover: {
-        x: "70%",
-        scale: 1.1,
-        rotate: "20deg",
-        filter: "grayscale(0%)",
-        transition: {
-        duration: 0.4,
-        type: "tween",
-        ease: "easeOut"
-        }
+const second = {
+  rest: {
+    rotate: "15deg",
+    scale: 0.95,
+    x: "50%",
+    filter: "grayscale(80%)",
+    transition: {
+      duration: 0.5,
+      type: "tween",
+      ease: "easeIn"
     }
+  },
+  hover: {
+    x: "70%",
+    scale: 1.1,
+    rotate: "20deg",
+    filter: "grayscale(0%)",
+    transition: {
+      duration: 0.4,
+      type: "tween",
+      ease: "easeOut"
+    }
+  }
 };
 
 const third = {
-    rest: {
-        scale: 1.1,
-        filter: "grayscale(80%)",
-        transition: {
-        duration: 0.5,
-        type: "tween",
-        ease: "easeIn"
-        }
-    },
-    hover: {
-        scale: 1.3,
-        filter: "grayscale(0%)",
-        transition: {
-        duration: 0.4,
-        type: "tween",
-        ease: "easeOut"
-        }
+  rest: {
+    scale: 1.1,
+    filter: "grayscale(80%)",
+    transition: {
+      duration: 0.5,
+      type: "tween",
+      ease: "easeIn"
     }
+  },
+  hover: {
+    scale: 1.3,
+    filter: "grayscale(0%)",
+    transition: {
+      duration: 0.4,
+      type: "tween",
+      ease: "easeOut"
+    }
+  }
 };
 
 type Ref = HTMLDivElement;
 type Props = {
-    variants: AnimationVariants;
-    backgroundImage: string;
-}
+  variants: AnimationVariants;
+  backgroundImage: string;
+};
 
 type DropImageProps = {
-    srcImage: string,
-    onChange: ChangeEventHandler<HTMLInputElement>,
+  srcImage: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
 };
 
 const PreviewImage = forwardRef<Ref, Props>((props, ref) => {
+  return (
+    <Box
+      bg="white"
+      top="0"
+      height="100%"
+      width="100%"
+      position="absolute"
+      borderWidth="1px"
+      borderStyle="solid"
+      rounded="sm"
+      borderColor="gray.400"
+      as={motion.div}
+      backgroundSize="cover"
+      backgroundRepeat="no-repeat"
+      backgroundPosition="center"
+      {...props}
+      ref={ref}
+    />
+  );
+});
 
-    return (
+const DropImage = ({ srcImage, onChange }: DropImageProps) => {
+  const controls = useAnimation();
+  const startAnimation = () => controls.start("hover");
+  const stopAnimation = () => controls.stop();
+  const nativeFilePickerRef = useRef<HTMLInputElement>(null);
+  return (
+    <Flex justifyContent="center">
+      <AspectRatio width="sm" ratio={1}>
         <Box
-        bg="white"
-        top="0"
-        height="100%"
-        width="100%"
-        position="absolute"
-        borderWidth="1px"
-        borderStyle="solid"
-        rounded="sm"
-        borderColor="gray.400"
-        as={motion.div}
-        backgroundSize="cover"
-        backgroundRepeat="no-repeat"
-        backgroundPosition="center"
-        {...props}
-        ref={ref}
-        />
-    );
-    });
-
-const DropImage = ({ srcImage, onChange }:DropImageProps) => {
-    const controls = useAnimation();
-    const startAnimation = () => controls.start("hover");
-    const stopAnimation = () => controls.stop();
-    const nativeFilePickerRef = useRef<HTMLInputElement>(null);
-    return (
-        <Flex justifyContent="center">
-        <AspectRatio width="sm" ratio={1}>
+          borderColor="green"
+          borderStyle="dashed"
+          borderWidth="2px"
+          rounded="md"
+          shadow="sm"
+          role="group"
+          transition="all 150ms ease-in-out"
+          _hover={{
+            shadow: "md"
+          }}
+          as={motion.div}
+          initial="rest"
+          animate="rest"
+          whileHover="hover">
+          <Box position="relative" height="100%" width="100%">
             <Box
-            borderColor="green"
-            borderStyle="dashed"
-            borderWidth="2px"
-            rounded="md"
-            shadow="sm"
-            role="group"
-            transition="all 150ms ease-in-out"
-            _hover={{
-                shadow: "md"
-            }}
-            as={motion.div}
-            initial="rest"
-            animate="rest"
-            whileHover="hover">
-            <Box position="relative" height="100%" width="100%">
-                <Box
-                position="absolute"
-                top="0"
-                left="0"
-                height="100%"
-                width="100%"
-                display="flex"
-                flexDirection="column">
-                {srcImage ? 
-                    (
-                        <Box height="70%" position="relative">
-                            <ChakraImage 
-                            src={srcImage || ""}
-                            alt="recipeImage"
-                            />
-                        </Box>
-                    ) 
-                    :
-                    (  
-                        <Stack
-                            height="100%"
-                            width="100%"
-                            display="flex"
-                            alignItems="center"
-                            justify="center"
-                            spacing="4"
-                            >
-                            <Box height="20" width="16" position="relative">
-                                <PreviewImage
-                                    variants={first}
-                                    backgroundImage={`url(${require("./imagesPreview/uploadPicture3.jpg")})`}
-                                />
-                                <PreviewImage
-                                    variants={second}
-                                    backgroundImage={`url(${require("./imagesPreview/uploadPicture2.jpg")})`}
-                                />
-                                <PreviewImage
-                                    variants={third}
-                                    backgroundImage={`url(${require("./imagesPreview/uploadPicture1.jpg")})`}
-                                />
-                            </Box>
-                        </Stack>
-                    )
-                }
-                    <Stack p="8" textAlign="center" spacing="1">
-                        <FormControl isRequired>
-                            <Input
-                                ref={nativeFilePickerRef}
-                                type="file"
-                                name="recipeImage"
-                                placeholder="Choose img"
-                                accept="image/png, image/jpeg, image/avif"
-                                height="100%"
-                                width="100%"
-                                position="absolute"
-                                top="0"
-                                left="0"
-                                opacity="0"
-                                aria-hidden="true"
-                                onDragEnter={startAnimation}
-                                onDragLeave={stopAnimation}
-                                onChange={onChange}
-                            />
-                            <Button 
-                                fontSize="lg"
-                                fontWeight="bold"
-                                onClick={() => {
-                                if (nativeFilePickerRef.current === null) return;
-                                nativeFilePickerRef.current.click();
-                                }} 
-                            >
-                                Сlick to upload
-                            </Button>
-                        </FormControl>
-                    </Stack>  
-                </Box> 
+              position="absolute"
+              top="0"
+              left="0"
+              height="100%"
+              width="100%"
+              display="flex"
+              flexDirection="column">
+              {srcImage ? (
+                <Box height="70%" position="relative">
+                  <ChakraImage src={srcImage || ""} alt="recipeImage" />
+                </Box>
+              ) : (
+                <Stack
+                  height="100%"
+                  width="100%"
+                  display="flex"
+                  alignItems="center"
+                  justify="center"
+                  spacing="4">
+                  <Box height="20" width="16" position="relative">
+                    <PreviewImage
+                      variants={first}
+                      backgroundImage={`url(${require("./imagesPreview/uploadPicture3.jpg")})`}
+                    />
+                    <PreviewImage
+                      variants={second}
+                      backgroundImage={`url(${require("./imagesPreview/uploadPicture2.jpg")})`}
+                    />
+                    <PreviewImage
+                      variants={third}
+                      backgroundImage={`url(${require("./imagesPreview/uploadPicture1.jpg")})`}
+                    />
+                  </Box>
+                </Stack>
+              )}
+              <Stack p="8" textAlign="center" spacing="1">
+                <FormControl>
+                  <Input
+                    ref={nativeFilePickerRef}
+                    type="file"
+                    name="recipeImage"
+                    placeholder="Choose img"
+                    accept="image/png, image/jpeg, image/avif"
+                    height="100%"
+                    width="100%"
+                    position="absolute"
+                    top="0"
+                    left="0"
+                    opacity="0"
+                    aria-hidden="true"
+                    onDragEnter={startAnimation}
+                    onDragLeave={stopAnimation}
+                    onChange={onChange}
+                  />
+                  <Button
+                    fontSize="lg"
+                    fontWeight="bold"
+                    onClick={() => {
+                      if (nativeFilePickerRef.current === null) return;
+                      nativeFilePickerRef.current.click();
+                    }}>
+                    Сlick to upload
+                  </Button>
+                </FormControl>
+              </Stack>
             </Box>
-            </Box>
-        </AspectRatio>
-        </Flex>
-    );
+          </Box>
+        </Box>
+      </AspectRatio>
+    </Flex>
+  );
 };
 
 export default DropImage;

--- a/src/components/SingleRecipePage/SingleRecipeIngredient.tsx
+++ b/src/components/SingleRecipePage/SingleRecipeIngredient.tsx
@@ -16,12 +16,16 @@ const SingleRecipeIngredient = ({
       return "for serving";
     } else if (ingredient.ingredientAmount === -3) {
       return "for garnish";
+    } else if (ingredient.ingredientAmount === -4) {
+      return "to serve";
+    } else if (ingredient.ingredientAmount === -5) {
+      return "to garnish";
     }
     return ingredient.ingredientAmount;
   };
   return (
-      <ListItem>
-        {`${ingredient.ingredientName}
+    <ListItem>
+      {`${ingredient.ingredientName}
         ${amount()} 
           ${
             ingredient.ingredientAmount <= 0
@@ -30,7 +34,7 @@ const SingleRecipeIngredient = ({
               ? ingredient.ingredientUnit
               : ""
           } `}
-      </ListItem>
+    </ListItem>
   );
 };
 export default SingleRecipeIngredient;

--- a/src/utils/OptionsData.tsx
+++ b/src/utils/OptionsData.tsx
@@ -1,62 +1,64 @@
 export const complexityOptions = [
-    { value: "easy", label: "easy" },
-    { value: "medium", label: "medium" },
-    { value: "difficult", label: "difficult" }
-]
+  { value: "easy", label: "easy" },
+  { value: "medium", label: "medium" },
+  { value: "difficult", label: "difficult" }
+];
 
 export const specialDietsOptions = [
-    { value: "None", label: "None" },
-    { value: "Weight Loss", label: "Weight Loss" },
-    { value: "Gluten-free", label: "Gluten-free" },
-    { value: "Pork-free", label: "Pork-free" },
-    { value: "Vegetarian", label: "Vegetarian" },
-    { value: "Vegan", label: "Vegan" },
-    { value: "Mediterranean", label: "Mediterranean" },
-    { value: "Diabetes Friendly", label: "Diabetes Friendly" },
-    { value: "Low Carb", label: "Low Carb" },
-    { value: "Keto", label: "Keto" },
-    { value: "Low Calorie", label: "Low Calorie" },
-    { value: "Lactose Free", label: "Lactose Free" },
-    { value: "Dairy Free", label: "Dairy Free" },
-    { value: "Soy Free", label: "Soy Free" },        
+  { value: "None", label: "None" },
+  { value: "Weight Loss", label: "Weight Loss" },
+  { value: "Gluten-free", label: "Gluten-free" },
+  { value: "Pork-free", label: "Pork-free" },
+  { value: "Vegetarian", label: "Vegetarian" },
+  { value: "Vegan", label: "Vegan" },
+  { value: "Mediterranean", label: "Mediterranean" },
+  { value: "Diabetes Friendly", label: "Diabetes Friendly" },
+  { value: "Low Carb", label: "Low Carb" },
+  { value: "Keto", label: "Keto" },
+  { value: "Low Calorie", label: "Low Calorie" },
+  { value: "Lactose Free", label: "Lactose Free" },
+  { value: "Dairy Free", label: "Dairy Free" },
+  { value: "Soy Free", label: "Soy Free" }
 ];
 
 export const categoriesOptions = [
-    {value: "Main Dish", label: "Main Dish"},
-    {value: "Snack", label: "Snack"},
-    {value: "Soup", label: "Soup"},
-    {value: "Cream Soup", label: "Cream Soup"},
-    {value: "Cocktail", label: "Cocktail"},
-    {value: "Salad", label: "Salad"},
-    {value: "Dessert", label: "Dessert"},
-    {value: "Kids Menu", label: "Kids Menu"},
-    {value: "Breakfast", label: "Breakfast"},
-    {value: "Appetizer", label: "Appetizer"},
-    {value: "Side Dish", label: "Side Dish"},
-    {value: "Sandwich", label: "Sandwich"},
-    {value: "Picnic Ideas", label: "Picnic Ideas"},
-    {value: "Smoothie", label: "Smoothie"},
-    {value: "Party Menu", label: "Party Menu"},
+  { value: "Main Dish", label: "Main Dish" },
+  { value: "Snack", label: "Snack" },
+  { value: "Soup", label: "Soup" },
+  { value: "Cream Soup", label: "Cream Soup" },
+  { value: "Cocktail", label: "Cocktail" },
+  { value: "Salad", label: "Salad" },
+  { value: "Dessert", label: "Dessert" },
+  { value: "Kids Menu", label: "Kids Menu" },
+  { value: "Breakfast", label: "Breakfast" },
+  { value: "Appetizer", label: "Appetizer" },
+  { value: "Side Dish", label: "Side Dish" },
+  { value: "Sandwich", label: "Sandwich" },
+  { value: "Picnic Ideas", label: "Picnic Ideas" },
+  { value: "Smoothie", label: "Smoothie" },
+  { value: "Party Menu", label: "Party Menu" }
 ];
 
 export const unitOptions = [
-    { value: "g", label: "g" },
-    { value: "kg", label: "kg" },
-    { value: "ml", label: "ml" },
-    { value: "l", label: "l" },
-    { value: "lbs", label: "lbs" },
-    { value: "cup", label: "cup" },
-    { value: "cups", label: "cups" },
-    { value: "tsp", label: "tsp" },    
-    { value: "tbsp", label: "tbsp" },  
-    { value: "cloves", label: "cloves" },     
-    { value: "medium", label: "medium" }, 
-    { value: "pinch", label: "pinch" }, 
-    { value: "other", label: "other" }, 
+  { value: "g", label: "g" },
+  { value: "kg", label: "kg" },
+  { value: "ml", label: "ml" },
+  { value: "l", label: "l" },
+  { value: "lbs", label: "lbs" },
+  { value: "cup", label: "cup" },
+  { value: "cups", label: "cups" },
+  { value: "tsp", label: "tsp" },
+  { value: "tbsp", label: "tbsp" },
+  { value: "cloves", label: "cloves" },
+  { value: "medium", label: "medium" },
+  { value: "pinch", label: "pinch" },
+  { value: "other", label: "other" }
 ];
 
 export const ingredientAmountOptions = [
-    { value: "-1", label: "to taste" },
-    { value: "-2", label: "for serving" },
-    { value: "-3", label: "for garnish" }, 
-];    
+  { value: "-1", label: "to taste" },
+  { value: "-2", label: "for serving" },
+  { value: "-3", label: "for garnish" },
+  { value: "-4", label: "to serve" },
+  { value: "-5", label: "to garnish" }
+];


### PR DESCRIPTION
## One Line Description
handle -4, -5 (to serve and to garnish) in recipe amount and remove "isRequired" in <Image/> on add recipe manually recipe 
## Requirements

_What this code should do_
since Backend pull request #38 in ingredient amount we have -4 and -5. Here we handle this amount
  const wordQty = {
    'to taste': -1,
    'for serving': -2,
    'for garnish': -3,
    'to serve': -4,
    'to garnish': -5,
  };
## Notes

_Any additional info_

## Test Steps

_Instructions on how to test the changes_
on add recipe manually page, edit recipe page, rendering recipe from AI and rendering single recipe page  ensure that all this cases handled. On add recipe manually page, edit recipe page you can add this new amount (to serve and to garnish)

the required was removes for image on add recipe manually page, because backend added default image
## UI/UX Outcome
<img width="215" alt="image" src="https://github.com/Code-the-Dream-School/dd-prac-team1-front/assets/106414157/c6fc1ae6-f358-4fcf-897a-0a5e46c1ef96">
<img width="276" alt="image" src="https://github.com/Code-the-Dream-School/dd-prac-team1-front/assets/106414157/df4876b3-39b9-4c25-b360-443f56b36b5e">


_Attach a screenshot here_

## Checklist

- The Linear ID is in the PR title
- My code follows best practices
- Documentation is included where needed
